### PR TITLE
Open dalite-ng admin in an overlay. 

### DIFF
--- a/dalite_xblock/public/js/dalite_xblock.js
+++ b/dalite_xblock/public/js/dalite_xblock.js
@@ -2,6 +2,19 @@ function DaliteXBlock(runtime, element) {
     LtiConsumerXBlock(runtime, element);
 
     // hack to make LTI Consumer css applied to Dalite XBlock
-    $(element).addClass("xblock-student_view-lti_consumer");
+    $(element).addClass("xblock-student_view-lti_consumer xblock-student_view");
     $(element).children(".xblock-dalite").addClass("lti_consumer");
+
+    $('.btn-lti-modal-dalite-admin').each(function (index, element) {
+        var $element = $(element);
+        $element.iframeModal({
+            top: 200,
+            closeButton: '.close-modal'
+        });
+        var modal_selector = $element.data("target");
+        var overlay_selector = (modal_selector + '_lean-overlay');
+        var onClose = function () { runtime.refreshXBlock($element.data("data-xblock-id")); };
+        $(overlay_selector).on("click", onClose);
+        $(modal_selector).on("click", ".close-modal", onClose);
+    });
 }

--- a/dalite_xblock/templates/dalite_xblock_data_not_filled.html
+++ b/dalite_xblock/templates/dalite_xblock_data_not_filled.html
@@ -3,5 +3,5 @@
 </h2>
 
 <div id="{{element_id}}"  class="${{element_class}} lti-consumer-container">
-    No question selected. Please click "Edit" and enter the assignment ID and question ID.
+    {{ message }}
 </div>

--- a/dalite_xblock/templates/dalite_xblock_lti_iframe.html
+++ b/dalite_xblock/templates/dalite_xblock_lti_iframe.html
@@ -1,0 +1,34 @@
+<div class="{{ element_class }}">
+
+<button
+    class="btn btn-pl-primary btn-base btn-lti-modal-dalite-admin"
+    data-target="#{{ element_id }}-{{ element_id_specifier }}"
+    data-xblock-id="{{ element_id}}"
+>
+    {{ dalite_admin_label }}  <i class="icon fa fa-external-link"></i>
+</button>
+
+<section
+    id="{{ element_id }}-{{ element_id_specifier }}"
+    class="modal lti-modal"
+    aria-hidden="true"
+    style="width:{{ modal_width }}%; left:{{ modal_horizontal_offset}}%; top:{{modal_vertical_offset}}%; bottom:{{modal_vertical_offset}}%;"
+    data-launch-url="{{ form_url }}/{{ form_url_suffix }}"
+>
+    <div class="inner-wrapper" role="dialog">
+        <button class="close-modal">
+            <i class="icon fa fa-remove"></i>
+            <span class="sr">Close</span>
+        </button>
+        <iframe
+            title="{{ display_name }}"
+            class="ltiLaunchFrame"
+            name="ltiFrame-{{ element_id }}"
+            src="{{ initial_launch_url }}"
+            allowfullscreen="true"
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+        ></iframe>
+    </div>
+</section>
+</div>


### PR DESCRIPTION
# Here is how this works.

Maybe we should document it somewhere more persistent than PR, but I have no idea where should I put it :) 
1. Basic interaction of the XBlock with LTI component is done by `lti_launch_handler` which is an XBlockHandler, that does some magic (that is not really important here) and at the end redirects user to `http://dalite/lti/`using POST request, passing in all lti parameters.
2. Dalite `/lti/` view basically does two things (plus some magic that is irrelevant for now): it authenticates the user to dalite (if user is not authenticated already); and then redirects user to proper view in Django.
3. Previous solution with `<a href='/admin' target='_blank'>` worked as the user was already authenticated --- he wouldn't have seen the button in the first place if he wasnt. 
4. Now we can't have this assumption so all requests have to pass through `lti_launch_handler` -> `/lti/` -> `/admin`. So I have just added new custom lti parameter named `action` that allows Dalite to redirect user either to question or to admin. 
# Authors concerns:
1. Previously this XBlock relied on CSS styles from 'xblock-lti-consumer', now we also rely on javascript code. 
2. I have also more or less "copied" parts of 'xblock-lti-consumer' templates --- as these were not really extensible. 
# Functionaltiies:

When author has provided `launch_url` but no queston ID he can access the admin to do add the question. 

![selection_002](https://cloud.githubusercontent.com/assets/112872/15576062/4c3aef3c-2356-11e6-83fe-b47aced09de4.png)

From LMS this view looks following: 

![selection_004](https://cloud.githubusercontent.com/assets/112872/15576082/6052c3c8-2356-11e6-8e92-2a06277c2a04.png)

Admin is visible in an overlay: 

![selection_003](https://cloud.githubusercontent.com/assets/112872/15576086/69fd7ca6-2356-11e6-99b3-4a7082357d06.png)

Question edition also: 

![selection_005](https://cloud.githubusercontent.com/assets/112872/15576098/75411e24-2356-11e6-9d13-cc957ef1356c.png)
# Testing instructions
### Setup steps
1. Install xblock-dalite in your devstack
2. Run dalite (dalite has nice setup instructions in readme) 
3. Create a LTI passport for `dalite-xblock`. Go to course in Studio -> Settings -> Avanced settings -> Lti Passports (this setting is a json formatted list of strings). See the readme in this repository for format. 
4. Add an assignment and one or two questions. 
5. Add dalite xblock to a course. 
### Verify that we have a clean upgrade path
1. Update daltie, but launch XBlock from master. 
2. Notice that while studio edition functionality doesn't work, everything else is OK. 
### Verify the functionality
1. Update Xblock. 
2. Restart lms and cms. 
3. Create new unit add Dalite Xblock to that unit. Notice that you have helpful message. 
4. Open this xblock in LMS notice different message. 
5. Edit dalite xblock and set only LTI ID. Notice that you have admin button that opens admin in overlay, and allows you to add new questions. 
6. Open this xblock in LMS notice lack of button, 
7. Edit dalite xblock once again and set assignment_id and question_id. Notice that you have a button that allows you to directly edit the question. 
8. Open this xblock in LMS notice lack of buttons. 
### Verify we didn't break LTI modules and `xblock-lti-provider`
1. Use LTI xblock and `xblock-lti-provider` and verify that admin is _not_ shown in LMS and Studio. 
